### PR TITLE
Payara 1789 start domain with single process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,11 @@ ENV PAYARA_VERSION 173
 
 ENV PKG_FILE_NAME payara-web-${PAYARA_VERSION}.zip
 
-# Download Payara Server and install
+# Download Payara Server, install, then remove downloaded file
 RUN \
  wget --quiet -O /opt/${PKG_FILE_NAME} ${PAYARA_PKG} && \
  unzip -qq /opt/${PKG_FILE_NAME} -d /opt && \
  chown -R payara:payara /opt && \
- # cleanup
  rm /opt/${PKG_FILE_NAME}
 
 USER payara
@@ -65,7 +64,7 @@ ENV AUTODEPLOY_DIR ${PAYARA_PATH}/glassfish/domains/${PAYARA_DOMAIN}/autodeploy
 # Default payara ports to expose
 EXPOSE 4848 8009 8080 8181
 
-ENV DEPLOY_COMMANDS=${PAYARA_PATH}/post-boot-commands.asadmin
+ENV POSTBOOT_COMMANDS=${PAYARA_PATH}/post-boot-commands.asadmin
 COPY generate_deploy_commands.sh ${PAYARA_PATH}/generate_deploy_commands.sh
 USER root
 RUN \
@@ -73,4 +72,4 @@ RUN \
  chmod a+x ${PAYARA_PATH}/generate_deploy_commands.sh
 USER payara
 
-ENTRYPOINT ${PAYARA_PATH}/generate_deploy_commands.sh && ${PAYARA_PATH}/bin/asadmin start-domain -v --postbootcommandfile ${DEPLOY_COMMANDS} ${PAYARA_DOMAIN}
+ENTRYPOINT ${PAYARA_PATH}/generate_deploy_commands.sh && ${PAYARA_PATH}/bin/asadmin start-domain -v --postbootcommandfile ${POSTBOOT_COMMANDS} ${PAYARA_DOMAIN}

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,11 +65,15 @@ ENV AUTODEPLOY_DIR ${PAYARA_PATH}/glassfish/domains/${PAYARA_DOMAIN}/autodeploy
 EXPOSE 4848 8009 8080 8181
 
 ENV POSTBOOT_COMMANDS=${PAYARA_PATH}/post-boot-commands.asadmin
+
 COPY generate_deploy_commands.sh ${PAYARA_PATH}/generate_deploy_commands.sh
+COPY bin/startInForeground.sh ${PAYARA_PATH}/bin/startInForeground.sh
+
 USER root
 RUN \
  chown -R payara:payara ${PAYARA_PATH}/generate_deploy_commands.sh && \
- chmod a+x ${PAYARA_PATH}/generate_deploy_commands.sh
+ chmod a+x ${PAYARA_PATH}/generate_deploy_commands.sh && \
+ chmod a+x ${PAYARA_PATH}/bin/startInForeground.sh
 USER payara
 
-ENTRYPOINT ${PAYARA_PATH}/generate_deploy_commands.sh && ${PAYARA_PATH}/bin/asadmin start-domain -v --postbootcommandfile ${POSTBOOT_COMMANDS} ${PAYARA_DOMAIN}
+ENTRYPOINT ${PAYARA_PATH}/generate_deploy_commands.sh && ${PAYARA_PATH}/bin/startInForeground.sh --postbootcommandfile ${POSTBOOT_COMMANDS} ${PAYARA_DOMAIN}

--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ docker run -p 8080:8080 --env PAYARA_DOMAIN=payaradomain payara/server-web
 
 If you also want to use the `AUTODEPLOY_DIR` variable (although this is discouraged), you need to overwrite the value of this variable accordingly. It points to the autodeploy directory of the `domain1` domain by default.
 
+## The default Docker entry point
+
+The default entry point does the following:
+
+- generates an asadmin script which deploys all applications found in the directory `/opt/payara41/deployments`, as described in _"Deployment on startup using a startup script"_
+- starts the server using the `startInForeground.sh` startup script, which avoids running 2 JVM instances as opposed to the command `asadmin start-domain --verbose`
+- uses the generated asadmin as a post boot command file to deploy all found applications at server start
+
+It's possible to run a custom set of asadmin commands by specifying the `POSTBOOT_COMMANDS` environment variable to point to the abslute path of the custom post boot command file. In that case, the default entry point won't deploy applications in `/opt/payara41/deployments`, you will have to specify the deploy command(s) in your custom post boot command file.
+
+You may also want to completely redefine the default entry point with the `--entrypoint` argument of `docker run`.
 
 # Details
 

--- a/bin/startInForeground.sh
+++ b/bin/startInForeground.sh
@@ -12,9 +12,15 @@
 #
 # It's possible to use any arguments of the start-domain command as arguments to startInForeground.sh
 #
+# By default, this script executes the asadmin tool which is found in the same directory. 
+# The AS_ADMIN_PATH environment variable can be used to specify an alternative path to the asadmin tool.
+#
 ##########################################################################################################
 
-AS_ADMIN_PATH=`dirname $0`/asadmin
+if [ -z "$AS_ADMIN_PATH" ]
+  then
+    AS_ADMIN_PATH=`dirname $0`/asadmin
+fi
 
 # The following command gets the command line to be executed by start-domain
 # - print the command line to the server with --dry-run, each argument on a separate line
@@ -22,7 +28,15 @@ AS_ADMIN_PATH=`dirname $0`/asadmin
 # - surround each line except with parenthesis to allow spaces in paths
 # - remove lines before and after the command line and squash commands on a single line
 
-COMMAND=`"$AS_ADMIN_PATH" start-domain --dry-run $@ | sed -n -e '/-read-stdin/d' -e 's/^\(.\)/"\1/' -e 's/\(.\)$/\1"/' -e '2,/^$/p'`
+OUTPUT=`"$AS_ADMIN_PATH" start-domain --dry-run $@`
+STATUS=$?
+if [ "$STATUS" -ne 0 ]
+  then
+    echo ERROR: $OUTPUT >&2
+    exit 1
+fi
+
+COMMAND=`echo "$OUTPUT" | sed -n -e '/-read-stdin/d' -e 's/^\(.\)/"\1/' -e 's/\(.\)$/\1"/' -e '2,/^$/p'`
 
 echo Executing Payara Server with the following command line:
 echo $COMMAND

--- a/bin/startInForeground.sh
+++ b/bin/startInForeground.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+##########################################################################################################
+#
+# This script is to execute Payara Server in foreground, mainly in a docker environment. 
+# It allows to avoid running 2 instances of JVM, which happens with the start-domain --verbose command.
+#
+# Usage:
+#   Running 
+#        startInForeground.sh <arguments>
+#   is equivalent to running
+#        asadmin start-domain <arguments>
+#
+# It's possible to use any arguments of the start-domain command as arguments to startInForeground.sh
+#
+##########################################################################################################
+
+AS_ADMIN_PATH=`dirname $0`/asadmin
+
+# The following command gets the command line to be executed by start-domain
+# - print the command line to the server with --dry-run, each argument on a separate line
+# - remove -read-string argument
+# - surround each line except with parenthesis to allow spaces in paths
+# - remove lines before and after the command line and squash commands on a single line
+
+COMMAND=`"$AS_ADMIN_PATH" start-domain --dry-run $@ | sed -n -e '/-read-stdin/d' -e 's/^\(.\)/"\1/' -e 's/\(.\)$/\1"/' -e '2,/^$/p'`
+
+echo Executing Payara Server with the following command line:
+echo $COMMAND
+echo
+
+# Run the server in foreground:
+
+eval $COMMAND

--- a/generate_deploy_commands.sh
+++ b/generate_deploy_commands.sh
@@ -1,8 +1,8 @@
 ################################################################################
 #
-# A script to generate the $DEPLOY_COMMANDS file with asadmin commands to deploy 
+# A script to generate the $POSTBOOT_COMMANDS file with asadmin commands to deploy 
 # all applications in $DEPLOY_DIR (either files or folders). 
-# The $DEPLOY_COMMANDS file can then be used with the start-domain using the
+# The $POSTBOOT_COMMANDS file can then be used with the start-domain using the
 #  --postbootcommandfile parameter to deploy applications on startup.
 #
 # Usage:
@@ -23,8 +23,8 @@ if [ x$1 != x ]
     DEPLOY_OPTS="$*"
 fi
 
-echo '# deployments after boot' > $DEPLOY_COMMANDS
+echo '# deployments after boot' > $POSTBOOT_COMMANDS
 for deployment in "${DEPLOY_DIR}"/*
   do
-    echo "deploy --force --enabled=true $DEPLOY_OPTS $deployment" >> $DEPLOY_COMMANDS
+    echo "deploy --force --enabled=true $DEPLOY_OPTS $deployment" >> $POSTBOOT_COMMANDS
 done


### PR DESCRIPTION
Improved starting of Payara Server in foreground to keep only one JVM process running. The launcher only retrieves command-line to be executed and doesn't execute it itself. Then the shell script uses this command line to start the second JVM process while the first one is already finished. Leads to much less memory consumption.

The same thing for Full Profile: https://github.com/payara/docker-payaraserver-full/pull/19